### PR TITLE
Fixed todos list remove on refresh

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import "./App.css";
 import Form from "./components/Form";
 import TodoList from "./components/TodoList";
 import { useState, useEffect } from "react";
+import store from './localStore';
 
 function App() {
   const [inputText, setInputText] = useState("");
@@ -11,46 +12,40 @@ function App() {
 
   // Run Once when the app start
   useEffect(() => {
-    // console.log("start");
     getLocalTodos();
   }, []);
 
+  const filterHandler = () => {
+    switch (status) {
+      case "completed":
+        setFilteredTodos(todos.filter((todo) => todo.completed));
+        break;
+      case "uncompleted":
+        setFilteredTodos(todos.filter((todo) => !todo.completed));
+        break;
+      default:
+        setFilteredTodos(todos);
+    }
+  };
+
+  // Update filtered list when change on status or todos item
   useEffect(() => {
-    const filterHandler = () => {
-      switch (status) {
-        case "completed":
-          setFilteredTodos(todos.filter((todo) => todo.completed));
-          break;
-        case "uncompleted":
-          setFilteredTodos(todos.filter((todo) => !todo.completed));
-          break;
-        default:
-          setFilteredTodos(todos);
-      }
-    };
-
-    const saveLocalTodos = () => {
-      // console.log("Save");
-      localStorage.setItem("todos", JSON.stringify(todos));
-    };
-
     filterHandler();
-    saveLocalTodos();
-    // console.log("hey");
   }, [todos, status]);
 
   const getLocalTodos = () => {
-    if (localStorage.getItem("todos") === null) {
-      // console.log("Clear");
-      localStorage.setItem("todos", JSON.stringify([]));
-    } else {
-      // console.log("text", localStorage.getItem("todos"));
-      let todoLocal = JSON.parse(localStorage.getItem("todos"));
-      console.log("local:", todoLocal);
-      setTodos(todoLocal);
-      console.log("Todos:", todos);
+    let todoLocal = store.get("todos");
+    if(!todoLocal || !todoLocal.length) {
+      todoLocal = []
     }
+    setTodos(todoLocal);
   };
+
+  // Set on local and state
+  const onSetTodo = (todoItems) => {
+    setTodos(todoItems);
+    store.set("todos", todoItems);
+  }
 
   return (
     <div className="App">
@@ -60,12 +55,12 @@ function App() {
       <Form
         inputText={inputText}
         todos={todos}
-        setTodos={setTodos}
+        setTodos={onSetTodo}
         setInputText={setInputText}
         setStatus={setStatus}
       ></Form>
       <TodoList
-        setTodos={setTodos}
+        setTodos={onSetTodo}
         todos={todos}
         filteredTodos={filteredTodos}
       ></TodoList>

--- a/src/localStore.js
+++ b/src/localStore.js
@@ -1,0 +1,20 @@
+const set = (keyName, keyValue) => {
+  localStorage.setItem(keyName, JSON.stringify(keyValue));
+};
+const get = (keyName, isString) => {
+  const data = localStorage.getItem(keyName);
+  if (isString) {
+    return data;
+  }
+  return JSON.parse(data);
+};
+const remove = (keyName) => {
+  localStorage.removeItem(keyName);
+};
+const clear = () => {
+  localStorage.clear();
+};
+
+const store = { set, get, remove, clear }
+
+export default store;


### PR DESCRIPTION
Hi @dickhfchan 

- Fixed the remove list on refresh from localstore
- Create localstore common methods
- **Optimise** and **reduce** some code on App.js file

**Approve this PR it will fix above items.**

Deployed here: https://react-todos-oiweng7hg-dickhfchan.vercel.app/
get link from view deployment. Works fine

I propose the https://www.upwork.com/ab/proposals/job/~0191d2eed82735e422 your job post.
**my profile is on upwork**: https://www.upwork.com/freelancers/~01f37a828fc0b546dd?viewMode=1
**email**: ntsagar9@gmail.com

**Issue was**:
when refresh the page it will set local todos as blank on **useEffect(() => ..., [todos, status])** this code. :)